### PR TITLE
Set up Database Handling in DotNetCoreShowcase Project

### DIFF
--- a/DotNetCoreShowcase.SampleDB/Models/Address/Address.cs
+++ b/DotNetCoreShowcase.SampleDB/Models/Address/Address.cs
@@ -6,7 +6,7 @@ namespace DotNetCoreShowcase.SampleDB.Models
     {
         public Guid AddressId { get; set; }
         public string AddressLine1 { get; set; }
-        public string? AddressLine2 { get; set; }
+        public string AddressLine2 { get; set; }
         public string City { get; set; }
         public string State { get; set; }
         public int Zip { get; set; }

--- a/DotNetCoreShowcase/DotNetCoreShowcase.csproj
+++ b/DotNetCoreShowcase/DotNetCoreShowcase.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -9,6 +9,13 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.21" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.21">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.21" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.21" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.21">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DotNetCoreShowcase/Models/Showcase/Addresses.cs
+++ b/DotNetCoreShowcase/Models/Showcase/Addresses.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DotNetCoreShowcase.Models.Showcase
+{
+    public partial class Addresses
+    {
+        public Addresses()
+        {
+            Users = new HashSet<Users>();
+        }
+
+        public Guid AddressId { get; set; }
+        public string AddressLine1 { get; set; }
+        public string AddressLine2 { get; set; }
+        public string City { get; set; }
+        public string State { get; set; }
+        public long Zip { get; set; }
+        public string Country { get; set; }
+
+        public virtual ICollection<Users> Users { get; set; }
+    }
+}

--- a/DotNetCoreShowcase/Models/Showcase/ShowcaseGeneratedContext.cs
+++ b/DotNetCoreShowcase/Models/Showcase/ShowcaseGeneratedContext.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+// Code scaffolded by EF Core assumes nullable reference types (NRTs) are not used or disabled.
+// If you have enabled NRTs for your project, then un-comment the following line:
+#nullable disable
+
+namespace DotNetCoreShowcase.Models.Showcase
+{
+    public partial class ShowcaseGeneratedContext : DbContext
+    {
+        public ShowcaseGeneratedContext()
+        {
+        }
+
+        public ShowcaseGeneratedContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<Addresses> Addresses { get; set; }
+        public virtual DbSet<Users> Users { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Addresses>(entity =>
+            {
+                entity.HasKey(e => e.AddressId);
+            });
+
+            modelBuilder.Entity<Users>(entity =>
+            {
+                entity.HasKey(e => e.UserId);
+
+                entity.HasIndex(e => e.AddressId);
+
+                entity.HasOne(d => d.Address)
+                    .WithMany(p => p.Users)
+                    .HasForeignKey(d => d.AddressId);
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}

--- a/DotNetCoreShowcase/Models/Showcase/Users.cs
+++ b/DotNetCoreShowcase/Models/Showcase/Users.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DotNetCoreShowcase.Models.Showcase
+{
+    public partial class Users
+    {
+        public Guid UserId { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public long CreationEpoch { get; set; }
+        public string Email { get; set; }
+        public Guid? AddressId { get; set; }
+
+        public virtual Addresses Address { get; set; }
+    }
+}

--- a/DotNetCoreShowcase/Startup.cs
+++ b/DotNetCoreShowcase/Startup.cs
@@ -12,6 +12,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using DotNetCoreShowcase.Models.Showcase;
+using Microsoft.EntityFrameworkCore;
 
 namespace DotNetCoreShowcase
 {
@@ -27,9 +29,12 @@ namespace DotNetCoreShowcase
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            string showcaseSampleConnectionString = this.Configuration.GetConnectionString("ShowcaseSampleConnection");
+
             services.AddControllers();
             services.AddSwaggerGen();
             services.AddMediatR(typeof(Startup).GetTypeInfo().Assembly);
+            services.AddDbContext<ShowcaseGeneratedContext>(o => o.UseSqlite(showcaseSampleConnectionString));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/DotNetCoreShowcase/appsettings.Development.json
+++ b/DotNetCoreShowcase/appsettings.Development.json
@@ -5,5 +5,8 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "ConnectionStrings": {
+    "ShowcaseSampleConnection": "Data Source=C:\\Users\\{USER}\\AppData\\Local\\DotNetCoreShowcase\\ShowcaseSample.sqlite"
   }
 }

--- a/DotNetCoreShowcase/appsettings.json
+++ b/DotNetCoreShowcase/appsettings.json
@@ -6,5 +6,8 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
+  "ConnectionStrings": {
+    "ShowcaseSampleConnection": "Data Source=C:\\Users\\{USER}\\AppData\\Local\\DotNetCoreShowcase\\ShowcaseSample.sqlite"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Set up and ran scaffolding on ShowcaseSample.sqlite.
Added stubbed out version of connection strings to appsettings.
Removed out unneeded null conditional on Address in DotnetCoreShowcase.SampleDB

Entity database first approach setup complete.